### PR TITLE
Addition of track quality BDT

### DIFF
--- a/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
+++ b/L1Trigger/TrackFindingTracklet/plugins/L1FPGATrackProducer.cc
@@ -93,6 +93,7 @@
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 
 #include "L1Trigger/TrackTrigger/interface/StubPtConsistency.h"
+#include "L1Trigger/TrackTrigger/interface/TrackQuality.h"
 
 //////////////
 // STD HEADERS
@@ -169,6 +170,9 @@ private:
 
   unsigned int nHelixPar_;
   bool extended_;
+
+  bool trackQuality_;
+  std::unique_ptr<TrackQuality> trackQualityModel_;
 
   std::map<string, vector<int>> dtclayerdisk;
 
@@ -280,6 +284,10 @@ L1FPGATrackProducer::L1FPGATrackProducer(edm::ParameterSet const& iConfig)
       edm::LogVerbatim("Tracklet") << "table_TED    :  " << tableTEDFile.fullPath()
                                    << "\n table_TRE    :  " << tableTREFile.fullPath();
     }
+  }
+  trackQuality_ = iConfig.getParameter<bool>("TrackQuality");
+  if (trackQuality_) {
+    trackQualityModel_ = std::make_unique<TrackQuality>(iConfig.getParameter<edm::ParameterSet>("TrackQualityPSet"));
   }
 }
 
@@ -683,6 +691,10 @@ void L1FPGATrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
     // set TTTrack word
     aTrack.setTrackWordBits();
+
+    if (trackQuality_) {
+      trackQualityModel_->setTrackQuality(aTrack);
+    }
 
     // test track word
     //aTrack.testTrackWordBits();

--- a/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/Tracklet_cfi.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from L1Trigger.TrackTrigger.TrackQualityParams_cfi import *
 
 TTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                TTStubSource = cms.InputTag("TTStubsFromPhase2TrackerDigis","StubAccepted"),
@@ -18,7 +19,10 @@ TTTracksFromTrackletEmulation = cms.EDProducer("L1FPGATrackProducer",
                                                wiresFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglass.dat'),
                                                DTCLinkFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/calcNumDTCLinks.txt'),
                                                DTCLinkLayerDiskFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/dtclinklayerdisk.dat'),
-                                               moduleCablingFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/modules_T5v3_27SP_nonant_tracklet.dat')
+                                               moduleCablingFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/modules_T5v3_27SP_nonant_tracklet.dat'),
+                                               # Quality Flag and Quality params
+                                               TrackQuality = cms.bool(True),
+                                               TrackQualityPSet = cms.PSet(TrackQualityParams),
     )
 
 TTTracksFromExtendedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
@@ -29,5 +33,8 @@ TTTracksFromExtendedTrackletEmulation = TTTracksFromTrackletEmulation.clone(
                                                wiresFile  = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/wires_hourglassExtended.dat'),
                                                # specifying where the TrackletEngineDisplaced(TED)/TripletEngine(TRE) tables are located
                                                tableTEDFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TED/table_TED_D1PHIA1_D2PHIA1.txt'),
-                                               tableTREFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TRE/table_TRE_D1AD2A_1.txt')
+                                               tableTREFile = cms.FileInPath('L1Trigger/TrackFindingTracklet/data/table_TRE/table_TRE_D1AD2A_1.txt'),
+                                                # Quality Flag and Quality params
+                                               TrackQuality = cms.bool(False),
+                                               TrackQualityPSet = cms.PSet(TrackQualityParams)
     )

--- a/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
+++ b/L1Trigger/TrackFindingTracklet/test/L1TrackNtupleMaker.cc
@@ -165,6 +165,7 @@ private:
   std::vector<int>* m_trk_unknown;
   std::vector<int>* m_trk_combinatoric;
   std::vector<int>* m_trk_fake;  //0 fake, 1 track from primary interaction, 2 secondary track
+  std::vector<float>* m_trk_MVA1;
   std::vector<int>* m_trk_matchtp_pdgid;
   std::vector<float>* m_trk_matchtp_pt;
   std::vector<float>* m_trk_matchtp_eta;
@@ -203,6 +204,7 @@ private:
   std::vector<float>* m_matchtrk_chi2rphi;
   std::vector<float>* m_matchtrk_chi2rz;
   std::vector<float>* m_matchtrk_bendchi2;
+  std::vector<float>* m_matchtrk_MVA1;
   std::vector<int>* m_matchtrk_nstub;
   std::vector<int>* m_matchtrk_lhits;
   std::vector<int>* m_matchtrk_dhits;
@@ -331,6 +333,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_trk_unknown = new std::vector<int>;
   m_trk_combinatoric = new std::vector<int>;
   m_trk_fake = new std::vector<int>;
+  m_trk_MVA1 = new std::vector<float>;
   m_trk_matchtp_pdgid = new std::vector<int>;
   m_trk_matchtp_pt = new std::vector<float>;
   m_trk_matchtp_eta = new std::vector<float>;
@@ -367,6 +370,7 @@ void L1TrackNtupleMaker::beginJob() {
   m_matchtrk_chi2rphi = new std::vector<float>;
   m_matchtrk_chi2rz = new std::vector<float>;
   m_matchtrk_bendchi2 = new std::vector<float>;
+  m_matchtrk_MVA1 = new std::vector<float>;
   m_matchtrk_nstub = new std::vector<int>;
   m_matchtrk_dhits = new std::vector<int>;
   m_matchtrk_lhits = new std::vector<int>;
@@ -426,6 +430,7 @@ void L1TrackNtupleMaker::beginJob() {
     eventTree->Branch("trk_unknown", &m_trk_unknown);
     eventTree->Branch("trk_combinatoric", &m_trk_combinatoric);
     eventTree->Branch("trk_fake", &m_trk_fake);
+    eventTree->Branch("trk_MVA1", &m_trk_MVA1);
     eventTree->Branch("trk_matchtp_pdgid", &m_trk_matchtp_pdgid);
     eventTree->Branch("trk_matchtp_pt", &m_trk_matchtp_pt);
     eventTree->Branch("trk_matchtp_eta", &m_trk_matchtp_eta);
@@ -467,6 +472,7 @@ void L1TrackNtupleMaker::beginJob() {
   eventTree->Branch("matchtrk_chi2rphi", &m_matchtrk_chi2rphi);
   eventTree->Branch("matchtrk_chi2rz", &m_matchtrk_chi2rz);
   eventTree->Branch("matchtrk_bendchi2", &m_matchtrk_bendchi2);
+  eventTree->Branch("matchtrk_MVA1", &m_matchtrk_MVA1);
   eventTree->Branch("matchtrk_nstub", &m_matchtrk_nstub);
   eventTree->Branch("matchtrk_lhits", &m_matchtrk_lhits);
   eventTree->Branch("matchtrk_dhits", &m_matchtrk_dhits);
@@ -550,6 +556,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_trk_unknown->clear();
     m_trk_combinatoric->clear();
     m_trk_fake->clear();
+    m_trk_MVA1->clear();
     m_trk_matchtp_pdgid->clear();
     m_trk_matchtp_pt->clear();
     m_trk_matchtp_eta->clear();
@@ -587,6 +594,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
   m_matchtrk_chi2rphi->clear();
   m_matchtrk_chi2rz->clear();
   m_matchtrk_bendchi2->clear();
+  m_matchtrk_MVA1->clear();
   m_matchtrk_nstub->clear();
   m_matchtrk_lhits->clear();
   m_matchtrk_dhits->clear();
@@ -860,6 +868,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       float tmp_trk_chi2rphi = iterL1Track->chi2XY();
       float tmp_trk_chi2rz = iterL1Track->chi2Z();
       float tmp_trk_bendchi2 = iterL1Track->stubPtConsistency();
+      float tmp_trk_MVA1 = iterL1Track->trkMVA1();
 
       std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_> >, TTStub<Ref_Phase2TrackerDigi_> > >
           stubRefs = iterL1Track->getStubRefs();
@@ -952,6 +961,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       m_trk_chi2rphi->push_back(tmp_trk_chi2rphi);
       m_trk_chi2rz->push_back(tmp_trk_chi2rz);
       m_trk_bendchi2->push_back(tmp_trk_bendchi2);
+      m_trk_MVA1->push_back(tmp_trk_MVA1);
       m_trk_nstub->push_back(tmp_trk_nstub);
       m_trk_dhits->push_back(tmp_trk_dhits);
       m_trk_lhits->push_back(tmp_trk_lhits);
@@ -1320,6 +1330,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     float tmp_matchtrk_chi2rphi = -999;
     float tmp_matchtrk_chi2rz = -999;
     float tmp_matchtrk_bendchi2 = -999;
+    float tmp_matchtrk_MVA1 = -999;
     int tmp_matchtrk_nstub = -999;
     int tmp_matchtrk_dhits = -999;
     int tmp_matchtrk_lhits = -999;
@@ -1345,6 +1356,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
       tmp_matchtrk_chi2rphi = matchedTracks.at(i_track)->chi2XY();
       tmp_matchtrk_chi2rz = matchedTracks.at(i_track)->chi2Z();
       tmp_matchtrk_bendchi2 = matchedTracks.at(i_track)->stubPtConsistency();
+      tmp_matchtrk_MVA1 = matchedTracks.at(i_track)->trkMVA1();
       tmp_matchtrk_nstub = (int)matchedTracks.at(i_track)->getStubRefs().size();
       tmp_matchtrk_seed = (int)matchedTracks.at(i_track)->trackSeedType();
       tmp_matchtrk_hitpattern = (int)matchedTracks.at(i_track)->hitPattern();
@@ -1404,6 +1416,7 @@ void L1TrackNtupleMaker::analyze(const edm::Event& iEvent, const edm::EventSetup
     m_matchtrk_chi2rphi->push_back(tmp_matchtrk_chi2rphi);
     m_matchtrk_chi2rz->push_back(tmp_matchtrk_chi2rz);
     m_matchtrk_bendchi2->push_back(tmp_matchtrk_bendchi2);
+    m_matchtrk_MVA1->push_back(tmp_matchtrk_MVA1);
     m_matchtrk_nstub->push_back(tmp_matchtrk_nstub);
     m_matchtrk_dhits->push_back(tmp_matchtrk_dhits);
     m_matchtrk_lhits->push_back(tmp_matchtrk_lhits);

--- a/L1Trigger/TrackTrigger/BuildFile.xml
+++ b/L1Trigger/TrackTrigger/BuildFile.xml
@@ -36,6 +36,7 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/L1TrackTrigger"/>
 <use name="DataFormats/Phase2TrackerDigi"/>
+<use name="PhysicsTools/ONNXRuntime"/>
 <export>
   <flags SEALPLUGIN="1"/>
   <lib name="1"/>

--- a/L1Trigger/TrackTrigger/interface/TrackQuality.h
+++ b/L1Trigger/TrackTrigger/interface/TrackQuality.h
@@ -1,0 +1,76 @@
+/*
+Track Quality Header file
+C.Brown 28/07/20
+*/
+
+#ifndef L1Trigger_TrackTrigger_interface_TrackQuality_h
+#define L1Trigger_TrackTrigger_interface_TrackQuality_h
+
+#include <iostream>
+#include <set>
+#include <vector>
+#include <memory>
+#include <string>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+class TrackQuality {
+public:
+  // Enum class used for determining prediction behaviour in setTrackQuality
+  enum class QualityAlgorithm { Cut, GBDT, NN, None };
+
+  //Default Constructor
+  TrackQuality();
+
+  TrackQuality(const edm::ParameterSet& qualityParams);
+
+  //Default Destructor
+  ~TrackQuality() = default;
+
+  // Controls the conversion between TTTrack features and ML model training features
+  std::vector<float> featureTransform(TTTrack<Ref_Phase2TrackerDigi_>& aTrack,
+                                      std::vector<std::string> const& featureNames);
+
+  // Passed by reference a track without MVA filled, method fills the track's MVA field
+  void setTrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack);
+
+  // To set private member data
+  void setCutParameters(std::string const& AlgorithmString,
+                        float maxZ0,
+                        float maxEta,
+                        float chi2dofMax,
+                        float bendchi2Max,
+                        float minPt,
+                        int nStubmin);
+
+  void setONNXModel(std::string const& AlgorithmString,
+                    edm::FileInPath const& ONNXmodel,
+                    std::string const& ONNXInputName,
+                    std::vector<std::string> const& featureNames);
+
+private:
+  // Private Member Data
+  QualityAlgorithm qualityAlgorithm_ = QualityAlgorithm::None;
+  edm::FileInPath ONNXmodel_;
+  std::string ONNXInputName_;
+  std::vector<std::string> featureNames_;
+  float maxZ0_;
+  float maxEta_;
+  float chi2dofMax_;
+  float bendchi2Max_;
+  float minPt_;
+  int nStubsmin_;
+  float ONNXInvRScaling_;
+};
+#endif

--- a/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
+++ b/L1Trigger/TrackTrigger/python/TrackQualityParams_cfi.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+TrackQualityParams = cms.PSet(qualityAlgorithm = cms.string("GBDT"), #None, Cut, NN, GBDT
+                              ONNXmodel = cms.FileInPath("L1Trigger/TrackTrigger/data/GBDT_default.onnx"),
+                              # The ONNX model should be found at this path, if you want a local version of the model:
+                              # git clone https://github.com/cms-data/L1Trigger-TrackTrigger.git L1Trigger/TrackTrigger/data
+                              ONNXInputName = cms.string("feature_input"),
+                              #Vector of strings of training features, in the order that the model was trained with
+                              featureNames = cms.vstring(["phi", "eta", "z0", "bendchi2_bin", "nstub", 
+                                                          "nlaymiss_interior", "chi2rphi_bin", "chi2rz_bin"]),
+                              # Parameters for cut based classifier, optimized for L1 Track MET
+                              # (Table 3.7  The Phase-2 Upgrade of the CMS Level-1 Trigger http://cds.cern.ch/record/2714892) 
+                              maxZ0 = cms.double ( 15. ) ,    # in cm
+                              maxEta = cms.double ( 2.4 ) ,
+                              chi2dofMax = cms.double( 40. ),
+                              bendchi2Max = cms.double( 2.4 ),
+                              minPt = cms.double( 2. ),       # in GeV
+                              nStubsmin = cms.int32( 4 ),
+                              
+                              ONNXInvRScale = cms.double(500)  # Scaling InvR to same order of magnitude as other variables for ML models
+                              )

--- a/L1Trigger/TrackTrigger/src/TrackQuality.cc
+++ b/L1Trigger/TrackTrigger/src/TrackQuality.cc
@@ -1,0 +1,305 @@
+/*
+Track Quality Body file
+C.Brown & C.Savard 07/2020
+*/
+
+#include "L1Trigger/TrackTrigger/interface/TrackQuality.h"
+#include "PhysicsTools/ONNXRuntime/interface/ONNXRuntime.h"
+
+//Constructors
+
+TrackQuality::TrackQuality() {}
+
+TrackQuality::TrackQuality(const edm::ParameterSet& qualityParams) {
+  std::string AlgorithmString = qualityParams.getParameter<std::string>("qualityAlgorithm");
+  // Unpacks EDM parameter set itself to save unecessary processing within TrackProducers
+  if (AlgorithmString == "Cut") {
+    setCutParameters(AlgorithmString,
+                     (float)qualityParams.getParameter<double>("maxZ0"),
+                     (float)qualityParams.getParameter<double>("maxEta"),
+                     (float)qualityParams.getParameter<double>("chi2dofMax"),
+                     (float)qualityParams.getParameter<double>("bendchi2Max"),
+                     (float)qualityParams.getParameter<double>("minPt"),
+                     qualityParams.getParameter<int>("nStubsmin"));
+  }
+
+  else {
+    setONNXModel(AlgorithmString,
+                 qualityParams.getParameter<edm::FileInPath>("ONNXmodel"),
+                 qualityParams.getParameter<std::string>("ONNXInputName"),
+                 qualityParams.getParameter<std::vector<std::string>>("featureNames"));
+    ONNXInvRScaling_ = qualityParams.getParameter<double>("ONNXInvRScale");
+  }
+}
+
+std::vector<float> TrackQuality::featureTransform(TTTrack<Ref_Phase2TrackerDigi_>& aTrack,
+                                                  std::vector<std::string> const& featureNames) {
+  // List input features for MVA in proper order below, the features options are
+  // {"log_chi2","log_chi2rphi","log_chi2rz","log_bendchi2","nstubs","lay1_hits","lay2_hits",
+  // "lay3_hits","lay4_hits","lay5_hits","lay6_hits","disk1_hits","disk2_hits","disk3_hits",
+  // "disk4_hits","disk5_hits","rinv","tanl","z0","dtot","ltot","chi2","chi2rz","chi2rphi",
+  // "bendchi2","pt","eta","nlaymiss_interior","phi","bendchi2_bin","chi2rz_bin","chi2rphi_bin"}
+
+  std::vector<float> transformedFeatures;
+
+  // Define feature map, filled as features are generated
+  std::map<std::string, float> feature_map;
+
+  // The following converts the 7 bit hitmask in the TTTrackword to an expected
+  // 11 bit hitmask based on the eta of the track
+  std::vector<int> hitpattern_binary = {0, 0, 0, 0, 0, 0, 0};
+  std::vector<int> hitpattern_expanded_binary = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  std::vector<float> eta_bins = {0.0, 0.2, 0.41, 0.62, 0.9, 1.26, 1.68, 2.08, 2.4};
+
+  // Expected hitmap table, each row corresponds to an eta bin, each value corresponds to
+  // the expected layer in the expanded hit pattern. The expanded hit pattern should be
+  // 11 bits but contains a 12th element so this hitmap table is symmetric
+  int hitmap[8][7] = {{0, 1, 2, 3, 4, 5, 11},
+                      {0, 1, 2, 3, 4, 5, 11},
+                      {0, 1, 2, 3, 4, 5, 11},
+                      {0, 1, 2, 3, 4, 5, 11},
+                      {0, 1, 2, 3, 4, 5, 11},
+                      {0, 1, 2, 6, 7, 8, 9},
+                      {0, 1, 7, 8, 9, 10, 11},
+                      {0, 6, 7, 8, 9, 10, 11}};
+
+  // iterate through bits of the hitpattern and compare to 1 filling the hitpattern binary vector
+  int tmp_trk_hitpattern = aTrack.hitPattern();
+  for (int i = 6; i >= 0; i--) {
+    int k = tmp_trk_hitpattern >> i;
+    if (k & 1)
+      hitpattern_binary[i] = 1;
+  }
+
+  // calculate number of missed interior layers from hitpattern
+  int nbits = floor(log2(tmp_trk_hitpattern)) + 1;
+  int lay_i = 0;
+  int tmp_trk_nlaymiss_interior = 0;
+  bool seq = false;
+  for (int i = 0; i < nbits; i++) {
+    lay_i = ((1 << i) & tmp_trk_hitpattern) >> i;  //0 or 1 in ith bit (right to left)
+
+    if (lay_i && !seq)
+      seq = true;  //sequence starts when first 1 found
+    if (!lay_i && seq)
+      tmp_trk_nlaymiss_interior++;
+  }
+
+  float eta = abs(aTrack.eta());
+  int eta_size = static_cast<int>(eta_bins.size());
+  // First iterate through eta bins
+
+  for (int j = 1; j < eta_size; j++) {
+    if (eta < eta_bins[j] && eta >= eta_bins[j - 1])  // if track in eta bin
+    {
+      // Iterate through hitpattern binary
+      for (int k = 0; k <= 6; k++)
+        // Fill expanded binary entries using the expected hitmap table positions
+        hitpattern_expanded_binary[hitmap[j - 1][k]] = hitpattern_binary[k];
+      break;
+    }
+  }
+
+  int tmp_trk_ltot = 0;
+  //calculate number of layer hits
+  for (int i = 0; i < 6; ++i) {
+    tmp_trk_ltot += hitpattern_expanded_binary[i];
+  }
+
+  int tmp_trk_dtot = 0;
+  //calculate number of disk hits
+  for (int i = 6; i < 11; ++i) {
+    tmp_trk_dtot += hitpattern_expanded_binary[i];
+  }
+
+  // bin bendchi2 variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
+  float tmp_trk_bendchi2 = aTrack.stubPtConsistency();
+  std::array<float, 8> bendchi2_bins{{0, 0.5, 1.25, 2, 3, 5, 10, 50}};
+  int n_bendchi2 = static_cast<int>(bendchi2_bins.size());
+  float tmp_trk_bendchi2_bin = -1;
+  for (int i = 0; i < n_bendchi2; i++) {
+    if (tmp_trk_bendchi2 >= bendchi2_bins[i] && tmp_trk_bendchi2 < bendchi2_bins[i + 1]) {
+      tmp_trk_bendchi2_bin = i;
+      break;
+    }
+  }
+  if (tmp_trk_bendchi2_bin < 0)
+    tmp_trk_bendchi2_bin = n_bendchi2;
+
+  // bin chi2rphi variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
+  float tmp_trk_chi2rphi = aTrack.chi2XY();
+  std::array<float, 16> chi2rphi_bins{{0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}};
+  int n_chi2rphi = static_cast<int>(chi2rphi_bins.size());
+  float tmp_trk_chi2rphi_bin = -1;
+  for (int i = 0; i < n_chi2rphi; i++) {
+    if (tmp_trk_chi2rphi >= chi2rphi_bins[i] && tmp_trk_chi2rphi < chi2rphi_bins[i + 1]) {
+      tmp_trk_chi2rphi_bin = i;
+      break;
+    }
+  }
+  if (tmp_trk_chi2rphi_bin < 0)
+    tmp_trk_chi2rphi_bin = n_chi2rphi;
+
+  // bin chi2rz variable (bins from https://twiki.cern.ch/twiki/bin/viewauth/CMS/HybridDataFormat#Fitted_Tracks_written_by_KalmanF)
+  float tmp_trk_chi2rz = aTrack.chi2Z();
+  std::array<float, 16> chi2rz_bins{{0, 0.25, 0.5, 1, 2, 3, 5, 7, 10, 20, 40, 100, 200, 500, 1000, 3000}};
+  int n_chi2rz = static_cast<int>(chi2rz_bins.size());
+  float tmp_trk_chi2rz_bin = -1;
+  for (int i = 0; i < n_chi2rz; i++) {
+    if (tmp_trk_chi2rz >= chi2rz_bins[i] && tmp_trk_chi2rz < chi2rz_bins[i + 1]) {
+      tmp_trk_chi2rz_bin = i;
+      break;
+    }
+  }
+  if (tmp_trk_chi2rz_bin < 0)
+    tmp_trk_chi2rz_bin = n_chi2rz;
+
+  // get the nstub
+  std::vector<edm::Ref<edmNew::DetSetVector<TTStub<Ref_Phase2TrackerDigi_>>, TTStub<Ref_Phase2TrackerDigi_>>> stubRefs =
+      aTrack.getStubRefs();
+
+  // fill the feature map
+  feature_map["nstub"] = stubRefs.size();
+  feature_map["rinv"] = ONNXInvRScaling_ * abs(aTrack.rInv());
+  feature_map["tanl"] = abs(aTrack.tanL());
+  feature_map["z0"] = aTrack.z0();
+  feature_map["phi"] = aTrack.phi();
+  feature_map["pt"] = aTrack.momentum().perp();
+  feature_map["eta"] = aTrack.eta();
+
+  float tmp_trk_chi2 = aTrack.chi2();
+  feature_map["chi2"] = tmp_trk_chi2;
+  feature_map["log_chi2"] = log(tmp_trk_chi2);
+
+  feature_map["chi2rphi"] = tmp_trk_chi2rphi;
+  feature_map["log_chi2rphi"] = log(tmp_trk_chi2rphi);
+
+  feature_map["chi2rz"] = tmp_trk_chi2rz;
+  feature_map["log_chi2rz"] = log(tmp_trk_chi2rz);
+
+  feature_map["chi2rz"] = tmp_trk_chi2rz;
+  feature_map["log_chi2rz"] = log(tmp_trk_chi2rz);
+
+  feature_map["bendchi2"] = tmp_trk_bendchi2;
+  feature_map["log_bendchi2"] = log(tmp_trk_bendchi2);
+
+  feature_map["lay1_hits"] = float(hitpattern_expanded_binary[0]);
+  feature_map["lay2_hits"] = float(hitpattern_expanded_binary[1]);
+  feature_map["lay3_hits"] = float(hitpattern_expanded_binary[2]);
+  feature_map["lay4_hits"] = float(hitpattern_expanded_binary[3]);
+  feature_map["lay5_hits"] = float(hitpattern_expanded_binary[4]);
+  feature_map["lay6_hits"] = float(hitpattern_expanded_binary[5]);
+  feature_map["disk1_hits"] = float(hitpattern_expanded_binary[6]);
+  feature_map["disk2_hits"] = float(hitpattern_expanded_binary[7]);
+  feature_map["disk3_hits"] = float(hitpattern_expanded_binary[8]);
+  feature_map["disk4_hits"] = float(hitpattern_expanded_binary[9]);
+  feature_map["disk5_hits"] = float(hitpattern_expanded_binary[10]);
+
+  feature_map["dtot"] = float(tmp_trk_dtot);
+  feature_map["ltot"] = float(tmp_trk_ltot);
+
+  feature_map["nlaymiss_interior"] = float(tmp_trk_nlaymiss_interior);
+  feature_map["bendchi2_bin"] = tmp_trk_bendchi2_bin;
+  feature_map["chi2rphi_bin"] = tmp_trk_chi2rphi_bin;
+  feature_map["chi2rz_bin"] = tmp_trk_chi2rz_bin;
+
+  // fill tensor with track params
+  transformedFeatures.reserve(featureNames.size());
+  for (const std::string& feature : featureNames)
+    transformedFeatures.push_back(feature_map[feature]);
+
+  return transformedFeatures;
+}
+
+void TrackQuality::setTrackQuality(TTTrack<Ref_Phase2TrackerDigi_>& aTrack) {
+  if (this->qualityAlgorithm_ == QualityAlgorithm::Cut) {
+    // Get Track parameters
+    float trk_pt = aTrack.momentum().perp();
+    float trk_bend_chi2 = aTrack.stubPtConsistency();
+    float trk_z0 = aTrack.z0();
+    float trk_eta = aTrack.momentum().eta();
+    float trk_chi2 = aTrack.chi2();
+    const auto& stubRefs = aTrack.getStubRefs();
+    int nStubs = stubRefs.size();
+
+    float classification = 0.0;  // Default classification is 0
+
+    if (trk_pt >= this->minPt_ && abs(trk_z0) < this->maxZ0_ && abs(trk_eta) < this->maxEta_ &&
+        trk_chi2 < this->chi2dofMax_ && trk_bend_chi2 < this->bendchi2Max_ && nStubs >= this->nStubsmin_)
+      classification = 1.0;
+    // Classification updated to 1 if conditions are met
+
+    aTrack.settrkMVA1(classification);
+  }
+
+  if ((this->qualityAlgorithm_ == QualityAlgorithm::NN) || (this->qualityAlgorithm_ == QualityAlgorithm::GBDT)) {
+    // Setup ONNX input and output names and arrays
+    std::vector<std::string> ortinput_names;
+    std::vector<std::string> ortoutput_names;
+
+    cms::Ort::FloatArrays ortinput;
+    cms::Ort::FloatArrays ortoutputs;
+
+    std::vector<float> Transformed_features = featureTransform(aTrack, this->featureNames_);
+    cms::Ort::ONNXRuntime Runtime(this->ONNXmodel_.fullPath());  //Setup ONNX runtime
+
+    ortinput_names.push_back(this->ONNXInputName_);
+    ortoutput_names = Runtime.getOutputNames();
+
+    //ONNX runtime recieves a vector of vectors of floats so push back the input
+    // vector of float to create a 1,1,21 ortinput
+    ortinput.push_back(Transformed_features);
+
+    // batch_size 1 as only one set of transformed features is being processed
+    int batch_size = 1;
+    // Run classification
+    ortoutputs = Runtime.run(ortinput_names, ortinput, ortoutput_names, batch_size);
+
+    if (this->qualityAlgorithm_ == QualityAlgorithm::NN) {
+      aTrack.settrkMVA1(ortoutputs[0][0]);
+    }
+
+    else if (this->qualityAlgorithm_ == QualityAlgorithm::GBDT) {
+      aTrack.settrkMVA1(ortoutputs[1][1]);
+    }
+    // Slight differences in the ONNX models of the GBDTs and NNs mean different
+    // indices of the ortoutput need to be accessed
+  }
+
+  else {
+    aTrack.settrkMVA1(-999);
+  }
+}
+
+void TrackQuality::setCutParameters(std::string const& AlgorithmString,
+                                    float maxZ0,
+                                    float maxEta,
+                                    float chi2dofMax,
+                                    float bendchi2Max,
+                                    float minPt,
+                                    int nStubmin) {
+  qualityAlgorithm_ = QualityAlgorithm::Cut;
+  maxZ0_ = maxZ0;
+  maxEta_ = maxEta;
+  chi2dofMax_ = chi2dofMax;
+  bendchi2Max_ = bendchi2Max;
+  minPt_ = minPt;
+  nStubsmin_ = nStubmin;
+}
+
+void TrackQuality::setONNXModel(std::string const& AlgorithmString,
+                                edm::FileInPath const& ONNXmodel,
+                                std::string const& ONNXInputName,
+                                std::vector<std::string> const& featureNames) {
+  //Convert algorithm string to Enum class for track by track comparison
+  if (AlgorithmString == "NN") {
+    qualityAlgorithm_ = QualityAlgorithm::NN;
+  } else if (AlgorithmString == "GBDT") {
+    qualityAlgorithm_ = QualityAlgorithm::GBDT;
+  } else {
+    qualityAlgorithm_ = QualityAlgorithm::None;
+  }
+  ONNXmodel_ = ONNXmodel;
+  ONNXInputName_ = ONNXInputName;
+  featureNames_ = featureNames;
+}

--- a/L1Trigger/VertexFinder/python/VertexProducer_cff.py
+++ b/L1Trigger/VertexFinder/python/VertexProducer_cff.py
@@ -72,13 +72,13 @@ VertexProducer = cms.EDProducer('VertexProducer',
         GenVxSmear = cms.double(0.2),
         # Use track weights from CNN
         UseCNNTrkWeights = cms.bool(True),
-        CNNTrackWeightGraph = cms.string("../../VertexFinder/data/cnnTrkWeight_v2.pb"),
+        CNNTrackWeightGraph = cms.string("L1Trigger/VertexFinder/data/cnnTrkWeight_v2.pb"),
         # Use track position CNN
         UseCNNPVZ0 = cms.bool(True),
-        CNNPVZ0Graph = cms.string("../../VertexFinder/data/cnnPVZ0_v2.pb"),
+        CNNPVZ0Graph = cms.string("L1Trigger/VertexFinder/data/cnnPVZ0_v2.pb"),
         # Associated tracks to vertex with CNN
         UseCNNTrackAssociation = cms.bool(True),
-        CNNGraph = cms.string("../../VertexFinder/data/cnnTrkAssoc_v2.pb")
+        CNNGraph = cms.string("L1Trigger/VertexFinder/data/cnnTrkAssoc_v2.pb")
     ),
   # Debug printout
   debug  = cms.uint32(1)


### PR DESCRIPTION
Addition of track quality BDT, new files in track trigger to load and run the BDT included. Additionally the L1FPGATrackProducer that runs the track finding now includes the running of a BDT. This BDT fills the track_word entry trackMVA1 which can been seen when running the L1TrackNtupleMaker, a new branch trk_MVA1 is created in the track Ntuples. Can also add these to the Ntuples created in the L1TrackObjectNtupleMaker if required. 

You will need to download the saved BDTs by running: git clone https://github.com/cms-data/L1Trigger-TrackTrigger.git L1Trigger/TrackTrigger/data  before running the track finding

(Also includes an update to the vertex finding config file that lets you run the vertex finding CNNs from any directory rather than specifically in the vertex finding directory)